### PR TITLE
added regex to ensure that the ORCID is in the right format in XML export

### DIFF
--- a/lib/cfg.d/z_datacite_mapping.pl
+++ b/lib/cfg.d/z_datacite_mapping.pl
@@ -60,6 +60,7 @@ $c->{datacite_mapping_creators} = sub {
             if ($orcid eq '') {
                 $creators->appendChild($author);
             } else {
+                $orcid =~ s#^(?:https?:\/\/)?orcid\.org\/(.*)$#$1#gi;
                 $author->appendChild($xml->create_data_element("nameIdentifier", $orcid, schemeURI =>"http://orcid.org/", nameIdentifierScheme=>"ORCID"));
             }
         }


### PR DESCRIPTION
The new ORCID guidance (https://support.orcid.org/knowledgebase/articles/116780) says that:

> When stored, the ORCID iD should be expressed as a full https URI: https://orcid.org/xxxx-xxxx-xxxx-xxxx, complete with the protocol (https://), and with hyphens in the identifier (xxxx-xxxx-xxxx-xxxx). 

However, the examples offered by DataCite (https://schema.datacite.org/meta/kernel-4.0/example/datacite-example-complicated-v4.0.xml) seem to indicate that the value of the ORCID needs to be in the xxxx-xxxx-xxxx-xxxx format (which is somehow preferable I believe).

I thought that this duality can generate inconsistent XML output, so I thought it would be a good idea to ensure that  the ORCID value is always exported as xxxx-xxxx-xxxx-xxxx as a DataCite XML, even if it is stored in the https://orcid.org/xxxx-xxxx-xxxx-xxxx format indicated by ORCID in the database.
So, 
https://orcid.org/xxxx-xxxx-xxxx-xxxx
http://orcid.org/xxxx-xxxx-xxxx-xxxx
orcid.org/xxxx-xxxx-xxxx-xxxx
will be xxxx-xxxx-xxxx-xxxx in the Datacite XML export. 