### PR TITLE
Add section on licence phrases to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ if($c->{datacitedoi}{action_coin}){
 If using a custom licence you must have phrases for your licences URI and typename (phrases for common licences are supplied in ``lib/lang/en/phrases/coinDOI.xml``). For example in ``archives/REPOID/cfg/lang/en/phrases/copyright.xml`` you might have these entries
 
 ```
-        <epp:phrase id="licenses_uri_cc_exampleorg">https://example.org/eprints/about/legal/</epp:phrase>
-        <epp:phrase id="licenses_typename_cc_exampleor">University of Example important licence</epp:phrase>
+<epp:phrase id="licenses_uri_cc_exampleorg">https://example.org/eprints/about/legal/</epp:phrase>
+<epp:phrase id="licenses_typename_cc_exampleor">University of Example important licence</epp:phrase>
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,18 @@ if($c->{datacitedoi}{action_coin}){
 
 ```
 
+
+If using a custom licence you must have phrases for your licences URI and typename (phrases for common licences are supplied in ``lib/lang/en/phrases/coinDOI.xml``). For example in ``archives/REPOID/cfg/lang/en/phrases/copyright.xml`` you might have these entries
+
+```
+        <epp:phrase id="licenses_uri_cc_exampleorg">https://example.org/eprints/about/legal/</epp:phrase>
+        <epp:phrase id="licenses_typename_cc_exampleor">University of Example important licence</epp:phrase>
+
+```
+
+See [EPrints wiki](https://wiki.eprints.org/w/Phrase_Format) for the full phrase file format and note that variables (like ``{$config{http_url}}``) do not appear to be supported in licenses_uri_*.
+
+
 How it works
 -------------
 


### PR DESCRIPTION
Our instance had its licence typename but no licence URI causing several errors:

This going to our logs
```
Undefined phrase: licenses_uri_cc_example (en) at line 238 in (eval 200)
anything really
```

And this in our output XML
```
<rightsList>
	<rights rightsURI="[&quot;licenses_uri_cc_example&quot; not defined]">University of Tasmania Standard License</rights>
</rightsList>