### PR TITLE
Reformat and update How it Works

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,19 +150,16 @@ if($c->{datacitedoi}{action_coin}){
 How it works
 -------------
 
-/lib/plugins/EPrints/Plugin/Event/DataCiteEvent.pm
-This is added to the queue and actually mints the doi.
+``lib/plugins/EPrints/Plugin/Event/DataCiteEvent.pm`` is added to the queue and actually mints the doi.
 
-lib/plugins/EPrints/Plugin/Sreen/EPrint/Staff/CoinDOI.pm
-This adds a button to enable staff to choose when to coin the DOI and request registration
+``lib/plugins/EPrints/Plugin/Sreen/EPrint/Staff/CoinDOI.pm`` adds a button to enable staff to choose when to coin the DOI and request registration.
 
-/lib/plugins/EPrints/Plugin/Export/DataCiteXML.pm
-This exports the metadata xml required for minting, this can be used independently and through the user interface. 
+``lib/plugins/EPrints/Plugin/Export/DataCiteXML.pm`` exports the metadata xml required for minting, this can be used independently and through the user interface. 
 
-By default the plugin uses the following mapping:
+By default the plugin produces the following mapping:
 ```xml
 <?xml version="1.0"?>
-<resource xmlns="http://datacite.org/schema/kernel-2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://datacite.org/schema/kernel-2.2 http://schema.datacite.org/meta/kernel-2.2/metadata.xsd">
+<resource xmlns="http://datacite.org/schema/kernel-4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
 	<identifier identifierType="DOI">[[From Config: $c->{datacitedoi}{prefix}/$c->{datacitedoi}{repoid]]/{{Eprintid}}</identifier>
 	<creators>
 		<creator>


### PR DESCRIPTION
I've changed the file paths to be quoted so they stand out and wrapped the
descriptive text on to the same line to improve flow.

All paths now start with lib/ (taking / from two of them) as its likely someone
copying these will want the relative nature of the paths preserved.

Lastly the schema version for DataCite has been updated, looks like it was
missed in the commits which changed the schema -
d7f8a91c8528a9232d90f85a5dcc27247cec5a5a and
aceb6403be078cc3b6fc72f892984ae76f4188d8 .