### PR TITLE
WIP: Libcurl backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In order to use the DataCite API the plugin requires the following perl librarie
 
 ```
 use LWP;
-use Crypt::SSLeay;
+use WWW::Curl;
 ```
 
 Installation

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ use LWP;
 use LWP::Protocol::https;
 ```
 
-For systems who's LWP::Protocol::https is older than 6.0.7
-(https://metacpan.org/release/LWP-Protocol-https) and connections will be made
-to SNI enabled servers WWW::Curl should be used instead.
+For systems who's
+[LWP::Protocol::https](https://metacpan.org/release/LWP-Protocol-https) is
+older than 6.0.7 and where connections will be made to SNI enabled servers
+WWW::Curl should be used instead.
 
 ```
 use WWW::Curl;

--- a/README.md
+++ b/README.md
@@ -11,14 +11,15 @@ use LWP;
 use LWP::Protocol::https;
 ```
 
-For systems who's LWP::Protocol::https is older than 6.0.7 (https://metacpan.org/release/LWP-Protocol-https)
-WWW::Curl should be used instead.
+For systems who's LWP::Protocol::https is older than 6.0.7
+(https://metacpan.org/release/LWP-Protocol-https) and connections will be made
+to SNI enabled servers WWW::Curl should be used instead.
 
 ```
 use WWW::Curl;
 ```
 
-If using WWW::Curl ensure $c->{datacitedoi}{use_curl} is defined.
+If using WWW::Curl ensure configuration item `$c->{datacitedoi}{use_curl}` is defined.
 
 
 Installation
@@ -56,6 +57,7 @@ $c->{datacitedoi}{eprintstatus} = {inbox=>0,buffer=>1,archive=>1,deletion=>0};
 
 # Choose which EPrint types are allowed (or denied) the ability to coin DOIs. Keys must be lower case and be eprints *types* not *type_names*.
 # Entries here can be explicitly skipped by setting 0; however those not listed with a 1 are not given a Coin DOI button by default.
+# To include the 'Coin DOI' button on all types leave this undefined.
 # $c->{datacitedoi}{typesallowed} = {
 # 				'article'=>0,                   # Article
 # 				'thesis'=>1,                    # Thesis
@@ -67,11 +69,11 @@ $c->{datacitedoi}{eprintstatus} = {inbox=>0,buffer=>1,archive=>1,deletion=>0};
 # doi = {prefix}/{repoid}/{eprintid}
 $c->{datacitedoi}{prefix} = "10.5072";
 $c->{datacitedoi}{repoid} = $c->{host};
-$c->{datacitedoi}{apiurl} = "https://mds.test.datacite.org";
+$c->{datacitedoi}{apiurl} = "https://mds.test.datacite.org/";
 $c->{datacitedoi}{user} = "USER";
 $c->{datacitedoi}{pass} = "PASS";
 
-# Backend library used for connecting to API; defaults to LWP but can also be Curl.
+# Backend library used for connecting to API; defaults to LWP (configuration item unset) but can also be Curl (configuration item set).
 # $c->{datacitedoi}{use_curl} = "yes";
 
 # Priviledge required to be able to mint DOIs
@@ -96,23 +98,27 @@ $c->{datacitedoi}{schemaLocation} = $c->{datacitedoi}{xmlns}." http://schema.dat
 # Need to map eprint type (article, dataset etc) to DOI ResourceType
 # Controlled list http://schema.datacite.org/meta/kernel-4.1/doc/DataCite-MetadataKernel_v4.1.pdf
 # where v is the ResourceType and a is the resourceTypeGeneral
+#$c->{datacitedoi}{typemap}{book_section} = {v=>'BookSection',a=>'Text'};
 $c->{datacitedoi}{typemap}{article} = {v=>'Article',a=>'Text'};
-$c->{datacitedoi}{typemap}{book_section} = {v=>'BookSection',a=>'Text'};
 $c->{datacitedoi}{typemap}{monograph} = {v=>'Monograph',a=>'Text'};
 $c->{datacitedoi}{typemap}{thesis} = {v=>'Thesis',a=>'Text'};
 $c->{datacitedoi}{typemap}{book} = {v=>'Book',a=>'Text'};
 $c->{datacitedoi}{typemap}{patent} = {v=>'Patent',a=>'Text'};
 $c->{datacitedoi}{typemap}{artefact} = {v=>'Artefact',a=>'PhysicalObject'};
-$c->{datacitedoi}{typemap}{performance} = {v=>'Performance',a=>'Event'};
+$c->{datacitedoi}{typemap}{exhibition} = {v=>'Exhibition',a=>'InteractiveResource'};
 $c->{datacitedoi}{typemap}{composition} = {v=>'Composition',a=>'Sound'};
+$c->{datacitedoi}{typemap}{performance} = {v=>'Performance',a=>'Event'};
 $c->{datacitedoi}{typemap}{image} = {v=>'Image',a=>'Image'};
+$c->{datacitedoi}{typemap}{video} = {v=>'Video',a=>'AudioVisual'};
+$c->{datacitedoi}{typemap}{audio} = {v=>'Audio',a=>'Sound'};
+$c->{datacitedoi}{typemap}{dataset} = {v=>'Dataset',a=>'Dataset'};
 $c->{datacitedoi}{typemap}{experiment} = {v=>'Experiment',a=>'Text'};
 $c->{datacitedoi}{typemap}{teaching_resource} = {v=>'TeachingResourse',a=>'InteractiveResource'};
 $c->{datacitedoi}{typemap}{other} = {v=>'Misc',a=>'Collection'};
-$c->{datacitedoi}{typemap}{dataset} = {v=>'Dataset',a=>'Dataset'};
-$c->{datacitedoi}{typemap}{audio} = {v=>'Audio',a=>'Sound'};
-$c->{datacitedoi}{typemap}{video} = {v=>'Video',a=>'Audiovisual'};
+#For use with recollect
 $c->{datacitedoi}{typemap}{data_collection} = {v=>'Dataset',a=>'Dataset'};
+$c->{datacitedoi}{typemap}{collection} = {v=>'Collection',a=>'Collection'};
+
 
 ###########################
 #### DOI syntax config ####

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ $c->{datacitedoi}{apiurl} = "https://mds.test.datacite.org";
 $c->{datacitedoi}{user} = "USER";
 $c->{datacitedoi}{pass} = "PASS";
 
+# Backend library used for connecting to API; defaults to LWP but can also be Curl.
+# $c->{datacitedoi}{use_curl} = "yes";
+
 # Priviledge required to be able to mint DOIs
 # See https://wiki.eprints.org/w/User_roles.pl for role and privilege configuration
 $c->{datacitedoi}{minters} = "eprint/edit:editor";

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ WWW::Curl should be used instead.
 use WWW::Curl;
 ```
 
+If using WWW::Curl ensure $c->{datacitedoi}{use_curl} is defined.
+
+
 Installation
 -------------
 

--- a/cfg/cfg.d/z_datacitedoi.pl
+++ b/cfg/cfg.d/z_datacitedoi.pl
@@ -32,6 +32,8 @@ $c->{datacitedoi}{apiurl} = "https://mds.test.datacite.org/";
 $c->{datacitedoi}{user} = "USER";
 $c->{datacitedoi}{pass} = "PASS";
 
+# Backend library used for connecting to API; defaults to LWP but can also be Curl.
+# $c->{datacitedoi}{use_curl} = "yes";
 
 # Priviledge required to be able to mint DOIs
 # See https://wiki.eprints.org/w/User_roles.pl for role and privilege configuration

--- a/cfg/cfg.d/z_datacitedoi.pl
+++ b/cfg/cfg.d/z_datacitedoi.pl
@@ -5,7 +5,7 @@ $c->{plugins}{"Event::DataCiteEvent"}{params}{disable} = 0;
 # Regex to match pre production servers
 # $c->{datacitedoi}{test_host_regex} = 'dev|test|preprod';
 
-#which field do use for the doi
+# which field to use for the doi
 $c->{datacitedoi}{eprintdoifield} = "id_number";
 
 #for xml:lang attributes in XML
@@ -32,7 +32,7 @@ $c->{datacitedoi}{apiurl} = "https://mds.test.datacite.org/";
 $c->{datacitedoi}{user} = "USER";
 $c->{datacitedoi}{pass} = "PASS";
 
-# Backend library used for connecting to API; defaults to LWP but can also be Curl.
+# Backend library used for connecting to API; defaults to LWP (configuration item unset) but can also be Curl (configuration item set).
 # $c->{datacitedoi}{use_curl} = "yes";
 
 # Priviledge required to be able to mint DOIs

--- a/lib/plugins/EPrints/Plugin/Event/DataCiteEvent.pm
+++ b/lib/plugins/EPrints/Plugin/Event/DataCiteEvent.pm
@@ -8,12 +8,7 @@ package EPrints::Plugin::Event::DataCiteEvent;
 
 use EPrints::Plugin::Event;
 
-if (defined $repository->get_conf( "datacitedoi", "get_curl")) {
-  use WWW::Curl::Easy;
-} else {
-  use LWP;
-  use HTTP:Headers::Util;
-}
+# Network client libraries included below in datacite_request
 
 @ISA = qw( EPrints::Plugin::Event );
 
@@ -76,14 +71,17 @@ sub datacite_doi
 		return undef;
 }
 
-
 sub datacite_request {
   # Test if we want to be using curl; if we don't run the 'old' LWP code
   if (defined $repository->get_conf( "datacitedoi", "get_curl")) {
+    use WWW::Curl::Easy;
     return datacite_request_curl(@_);
   } else {
     my ($method, $url, $user_name, $user_pw, $content, $content_type) = @_;
  
+    use LWP;
+    use HTTP:Headers::Util;
+  
     # build request
     my $headers = HTTP::Headers->new(
       'Accept'  => 'application/xml',

--- a/lib/plugins/EPrints/Plugin/Event/DataCiteEvent.pm
+++ b/lib/plugins/EPrints/Plugin/Event/DataCiteEvent.pm
@@ -42,7 +42,15 @@ sub datacite_doi
 		my $user_pw = $repository->get_conf( "datacitedoi", "pass");
 
 		#register metadata;
-		my($response_content, $response_code) =  datacite_request("POST", $url."metadata", $user_name, $user_pw, $xml, "application/xml;charset=UTF-8");
+		my $response_content;
+		my $response_code;
+		# Test if we want to be using curl; if we don't run the 'old' LWP code
+		if (defined $repository->get_conf( "datacitedoi", "get_curl")) {
+			($response_content, $response_code) =  datacite_request_curl($url."metadata", $user_name, $user_pw, $xml, "application/xml;charset=UTF-8");
+		} else {
+			($response_content, $response_code) =  datacite_request("POST", $url."metadata", $user_name, $user_pw, $xml, "application/xml;charset=UTF-8");
+		}
+
 		if($response_code !~ /20(1|0)/){
 			$repository->log("Metadata response from datacite api: $response_code: $response_content");
 			$repository->log("BTW the \$doi was:\n$thisdoi");
@@ -56,7 +64,12 @@ sub datacite_doi
 			$repo_url.= $dataobj->internal_uri;
 		}
  		my $doi_reg = "doi=$thisdoi\nurl=".$repo_url;
-		($response_content, $response_code)= datacite_request("POST", $url."doi", $user_name, $user_pw, $doi_reg, "text/plain; charset=utf8");
+		# Test if we want to be using curl; if we don't run the 'old' LWP code
+		if (defined $repository->get_conf( "datacitedoi", "get_curl")) {
+			($response_content, $response_code)= datacite_request_curl($url."doi", $user_name, $user_pw, $doi_reg, "text/plain; charset=utf8");
+		} else {
+			($response_content, $response_code)= datacite_request("POST", $url."doi", $user_name, $user_pw, $doi_reg, "text/plain; charset=utf8");
+		}
 		if($response_code  !~ /20(1|0)/){
 			$repository->log("Registration response from datacite api: $response_code: $response_content");
 			$repository->log("BTW the \$doi_reg was:\n$doi_reg");
@@ -71,41 +84,36 @@ sub datacite_doi
 		return undef;
 }
 
+
 sub datacite_request {
-  # Test if we want to be using curl; if we don't run the 'old' LWP code
-  if (defined $repository->get_conf( "datacitedoi", "get_curl")) {
-    use WWW::Curl::Easy;
-    return datacite_request_curl(@_);
-  } else {
-    my ($method, $url, $user_name, $user_pw, $content, $content_type) = @_;
+  my ($method, $url, $user_name, $user_pw, $content, $content_type) = @_;
 
-    use LWP;
-    use HTTP::Headers::Util;
+  use LWP;
+  use HTTP::Headers::Util;
 
-    # build request
-    my $headers = HTTP::Headers->new(
-      'Accept'  => 'application/xml',
-      'Content-Type' => $content_type
-    );
+  # build request
+  my $headers = HTTP::Headers->new(
+    'Accept'  => 'application/xml',
+    'Content-Type' => $content_type
+  );
 
-    my $req = HTTP::Request->new(
-      $method => $url,
-      $headers, Encode::encode_utf8( $content )
-    );
-    $req->authorization_basic($user_name, $user_pw);
- 
-    # pass request to the user agent and get a response back
-    my $ua = LWP::UserAgent->new;
-    my $res = $ua->request($req);
- 
-    return ($res->content(),$res->code());
-  }
+  my $req = HTTP::Request->new(
+    $method => $url,
+    $headers, Encode::encode_utf8( $content )
+  );
+  $req->authorization_basic($user_name, $user_pw);
+
+  # pass request to the user agent and get a response back
+  my $ua = LWP::UserAgent->new;
+  my $res = $ua->request($req);
+
+  return ($res->content(),$res->code());
 }
 
 
 
 sub datacite_request_curl {
-  my ($method, $url, $user_name, $user_pw, $content, $content_type) = @_;
+  my ($url, $user_name, $user_pw, $content, $content_type) = @_;
 
   # build request
   my @myheaders = (
@@ -117,7 +125,7 @@ sub datacite_request_curl {
   $curl->setopt(CURLOPT_FAILONERROR,1);
   # $curl->setopt(CURLOPT_HEADER,1);
   # $curl->setopt(CURLOPT_VERBOSE, 1);
-  $curl->setopt(CURLOPT_POST, 1);  # TODO: Make conditional on $method
+  $curl->setopt(CURLOPT_POST, 1);
   $curl->setopt(CURLOPT_URL, $url);
   $curl->setopt(CURLOPT_USERNAME, $user_name);
   $curl->setopt(CURLOPT_PASSWORD, $user_pw);
@@ -135,17 +143,16 @@ sub datacite_request_curl {
   # Use response to determine HTTP status code
   $http_retcode    = $curl->getinfo(CURLINFO_HTTP_CODE);
 
-  # Ensure we return a useful (well, usable) message and error response
-  if ($retcode == 0) {
-    $content = "Received response: $response_body\n";
-  } else {
-    $http_prose = $curl->strerror($retcode);
-    $content = "An error happened: $http_prose $http_retcode (Curl error code $retcode)\n";
-  }
+#   # Ensure we return a useful (well, usable) message and error response
+#   if ($retcode == 0) {
+#     $content = "Received response: $response_body\n";
+#   } else {
+#     $http_prose = $curl->strerror($retcode);
+#     $content = "An error happened: $http_prose $http_retcode (Curl error code $retcode)\n";
+#   }
 
   return ($content, $http_retcode);
 }
-
 
 
 #RM lets do the DOI coining somewhere (reasonably) accessible

--- a/lib/plugins/EPrints/Plugin/Event/DataCiteEvent.pm
+++ b/lib/plugins/EPrints/Plugin/Event/DataCiteEvent.pm
@@ -78,16 +78,16 @@ sub datacite_request {
     return datacite_request_curl(@_);
   } else {
     my ($method, $url, $user_name, $user_pw, $content, $content_type) = @_;
- 
+
     use LWP;
     use HTTP::Headers::Util;
-  
+
     # build request
     my $headers = HTTP::Headers->new(
       'Accept'  => 'application/xml',
       'Content-Type' => $content_type
     );
-    
+
     my $req = HTTP::Request->new(
       $method => $url,
       $headers, Encode::encode_utf8( $content )

--- a/lib/plugins/EPrints/Plugin/Event/DataCiteEvent.pm
+++ b/lib/plugins/EPrints/Plugin/Event/DataCiteEvent.pm
@@ -72,7 +72,6 @@ sub datacite_doi
 
 
 sub datacite_request {
-  print STDERR "Performing DataCite request\n";
   my ($method, $url, $user_name, $user_pw, $content, $content_type) = @_;
 
   # build request
@@ -80,8 +79,6 @@ sub datacite_request {
     "Accept: application/xml",
     "Content-Type: $content_type"
   );
-  print STDERR "Build headers array\n";
-
   my $curl = new WWW::Curl::Easy;
 
   $curl->setopt(CURLOPT_FAILONERROR,1);
@@ -99,12 +96,8 @@ sub datacite_request {
   $curl->setopt(CURLOPT_WRITEDATA,$fileb);
 
 
-  print STDERR "Finished setting Curl options\n";
-
   # pass request and get a response back
   my $retcode = $curl->perform;
-
-  print STDERR "Network transaction complete\n";
 
   # Use response to determine HTTP status code
   $http_retcode    = $curl->getinfo(CURLINFO_HTTP_CODE);
@@ -117,9 +110,6 @@ sub datacite_request {
     $content = "An error happened: $http_prose $http_retcode (Curl error code $retcode)\n";
   }
 
-  print STDERR "Return code checked (Curl $retcode; HTTP $http_retcode), suitable message generated\n";
-
-  print STDERR "About to return() and leave datacite_request{}\n";
   return ($content, $http_retcode);
 }
 

--- a/lib/plugins/EPrints/Plugin/Event/DataCiteEvent.pm
+++ b/lib/plugins/EPrints/Plugin/Event/DataCiteEvent.pm
@@ -80,7 +80,7 @@ sub datacite_request {
     my ($method, $url, $user_name, $user_pw, $content, $content_type) = @_;
  
     use LWP;
-    use HTTP:Headers::Util;
+    use HTTP::Headers::Util;
   
     # build request
     my $headers = HTTP::Headers->new(

--- a/lib/plugins/EPrints/Plugin/Event/DataCiteEvent.pm
+++ b/lib/plugins/EPrints/Plugin/Event/DataCiteEvent.pm
@@ -82,8 +82,8 @@ sub datacite_request {
   my $curl = new WWW::Curl::Easy;
 
   $curl->setopt(CURLOPT_FAILONERROR,1);
-  $curl->setopt(CURLOPT_HEADER,1); # when it works put this behind an 'if debug'
-  $curl->setopt(CURLOPT_VERBOSE, 1); # when it works put this behind an 'if debug'
+  # $curl->setopt(CURLOPT_HEADER,1);
+  # $curl->setopt(CURLOPT_VERBOSE, 1);
   $curl->setopt(CURLOPT_POST, 1);  # TODO: Make conditional on $method
   $curl->setopt(CURLOPT_URL, $url);
   $curl->setopt(CURLOPT_USERNAME, $user_name);


### PR DESCRIPTION
Hi,
I'm after feedback on this change. Its only required in cases where the OS doesn't support SNI - in my case RHEL6 but I expect a similarly aged Debian/Ubuntu would see the same problem.

The main thing I want to know is if I should try and if/else it out so (for example) if WWW::Curl is available that is used instead of HTTP::Headers and SSLeay.

Do you need this change? If you see this, you need the changes:
```
bash-4.1$ lwp-request -U -S -e -d  https://test.datacite.org:443
GET https://test.datacite.org:443
User-Agent: lwp-request/5.827 libwww-perl/5.833

GET https://test.datacite.org:443 --> 500 Can't connect to test.datacite.org:443 (SSL connect attempt failed with unknown errorerror:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure)
Content-Type: text/plain
Client-Date: Wed, 12 Sep 2018 22:54:39 GMT
Client-Warning: Internal response
```

If you see something like this, you should be fine unmodified:
```
bash-4.1$ lwp-request -U -S -e -d  https://researchdata.ands.org.au/api/doi/datacite
Enter username for ands at researchdata.ands.org.au:443: [username]
Password: 
GET https://researchdata.ands.org.au/api/doi/datacite
Authorization: Basic [big long string]
User-Agent: lwp-request/5.827 libwww-perl/5.833

GET https://researchdata.ands.org.au/api/doi/datacite --> 401 Unauthorized
GET https://researchdata.ands.org.au/api/doi/datacite --> 200 OK
```

We have used this code to mint several DOIs so the basic functionality is working.