### PR TITLE
Update the controlled mapping list to schema 4.1

### DIFF
--- a/cfg/cfg.d/z_datacitedoi.pl
+++ b/cfg/cfg.d/z_datacitedoi.pl
@@ -30,10 +30,12 @@ $c->{datacitedoi}{publisher} = "Eprints Repo";
 # Namespace and location for datacite XML schema
 # feel free to update, though no guarantees it'll be accepted if you do
 $c->{datacitedoi}{xmlns} = "http://datacite.org/schema/kernel-4";
+# Try this instead:
+# $c->{datacitedoi}{schemaLocation} = $c->{datacitedoi}{xmlns}." ".$c->{datacitedoi}{xmlns}."/metadata.xsd";
 $c->{datacitedoi}{schemaLocation} = $c->{datacitedoi}{xmlns}." http://schema.datacite.org/meta/kernel-4/metadata.xsd";
 
-# need to map eprint type (article, dataset etc) to ResourceType
-# Controled list http://schema.datacite.org/meta/kernel-2.2/doc/DataCite-MetadataKernel_v2.2.pdf
+# Need to map eprint type (article, dataset etc) to DOI ResourceType
+# Controlled list http://schema.datacite.org/meta/kernel-4.1/doc/DataCite-MetadataKernel_v4.1.pdf
 # where v is the ResourceType and a is the resourceTypeGeneral
 $c->{datacitedoi}{typemap}{article} = {v=>'Article',a=>'Text'};
 $c->{datacitedoi}{typemap}{book_section} = {v=>'BookSection',a=>'Text'};
@@ -50,8 +52,9 @@ $c->{datacitedoi}{typemap}{teaching_resource} = {v=>'TeachingResourse',a=>'Inter
 $c->{datacitedoi}{typemap}{other} = {v=>'Misc',a=>'Collection'};
 $c->{datacitedoi}{typemap}{dataset} = {v=>'Dataset',a=>'Dataset'};
 $c->{datacitedoi}{typemap}{audio} = {v=>'Audio',a=>'Sound'};
-$c->{datacitedoi}{typemap}{video} = {v=>'Video',a=>'Film'};
+$c->{datacitedoi}{typemap}{video} = {v=>'Video',a=>'Audiovisual'};
 $c->{datacitedoi}{typemap}{data_collection} = {v=>'Dataset',a=>'Dataset'};
+
 ###########################
 #### DOI syntax config ####
 ###########################


### PR DESCRIPTION
The changes (well, change: removal of Film) happend in 3.0 but 4.1 appears to
have the same list as 3.0 was released with.