### PR TITLE
WIP: Only permit coining DOIs for certain eprint types

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ $c->{datacitedoi}{eprintdoifield} = "id_number";
 #When should you register/update doi info.
 $c->{datacitedoi}{eprintstatus} = {inbox=>0,buffer=>1,archive=>1,deletion=>0};
 
+# Choose which EPrint types are allowed (or denied) the ability to coin DOIs. Keys must be lower case and be eprints *types* not *type_names*.
+# Entries here can be explicitly skipped by setting 0; however those not listed with a 1 are not given a Coin DOI button by default.
+# $c->{datacitedoi}{typesallowed} = {
+# 				'article'=>0,                   # Article
+# 				'thesis'=>1,                    # Thesis
+# 				'creative_works' => 1,          # Creative Works
+# 				'dataset' => 1,                 # Dataset
+#                                 };
+
 #set these (you will get the from data site)
 # doi = {prefix}/{repoid}/{eprintid}
 $c->{datacitedoi}{prefix} = "10.5072";

--- a/cfg/cfg.d/z_datacitedoi.pl
+++ b/cfg/cfg.d/z_datacitedoi.pl
@@ -11,6 +11,16 @@ $c->{datacitedoi}{defaultlangtag} = "en-GB";
 #When should you register/update doi info.
 $c->{datacitedoi}{eprintstatus} = {inbox=>0,buffer=>1,archive=>1,deletion=>0};
 
+# Choose which EPrint types are allowed (or denied) the ability to coin DOIs. Keys must be lower case and be eprints *types* not *type_names*.
+# Entries here can be explicitly skipped by setting 0; however those not listed with a 1 are not given a Coin DOI button by default.
+# To include the 'Coin DOI' button on all types leave this undefined.
+# $c->{datacitedoi}{typesallowed} = {
+# 				'article'=>0,                   # Article
+# 				'thesis'=>1,                    # Thesis
+# 				'creative_works' => 1,          # Creative Works
+# 				'dataset' => 1,                 # Dataset
+#                                 };
+
 #set these (you will get the from data site)
 # doi = {prefix}/{repoid}/{eprintid}
 $c->{datacitedoi}{prefix} = "10.5072";

--- a/lib/plugins/EPrints/Plugin/Screen/EPrint/Staff/CoinDOI.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/EPrint/Staff/CoinDOI.pm
@@ -49,6 +49,12 @@ sub allow_coindoi
 	#TODO a version that works for documents too
 	my $dataobj = $self->{processor}->{eprint}; 
         return 0 unless $repository->get_conf( "datacitedoi", "eprintstatus",  $dataobj->value( "eprint_status" ));
+
+	if (defined $repository->get_conf( "datacitedoi", "typesallowed")) {
+		# Is this type of eprint allowed/denied coining?
+		return 0 unless $repository->get_conf( "datacitedoi", "typesallowed",  $dataobj->get_type);
+	}
+
   # Don't show coinDOI button if a DOI is already registered 
   return 0 if $dataobj->is_set($repository->get_conf( "datacitedoi", "eprintdoifield"));
   return $self->allow( "eprint/edit:editor" );


### PR DESCRIPTION
This configuration option allows for altering which types of eprints that will
display a 'Coin DOI' button on their administration page.

We are currently using this functionality (in dev) so can attest to it having some
real use testing.