### PR TITLE
Make DOI minters configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ $c->{datacitedoi}{apiurl} = "https://mds.test.datacite.org";
 $c->{datacitedoi}{user} = "USER";
 $c->{datacitedoi}{pass} = "PASS";
 
+# Priviledge required to be able to mint DOIs
+# See https://wiki.eprints.org/w/User_roles.pl for role and privilege configuration
+$c->{datacitedoi}{minters} = "eprint/edit:editor";
+
 # datacite requires a Publisher 
 # The name of the entity that holds, archives, publishes, 
 # prints, distributes, releases, issues, or produces the 

--- a/cfg/cfg.d/z_datacitedoi.pl
+++ b/cfg/cfg.d/z_datacitedoi.pl
@@ -19,6 +19,10 @@ $c->{datacitedoi}{apiurl} = "https://mds.test.datacite.org/";
 $c->{datacitedoi}{user} = "USER";
 $c->{datacitedoi}{pass} = "PASS";
 
+# Priviledge required to be able to mint DOIs
+# See https://wiki.eprints.org/w/User_roles.pl for role and privilege configuration
+$c->{datacitedoi}{minters} = "eprint/edit:editor";
+
 # datacite requires a Publisher
 # The name of the entity that holds, archives, publishes,
 # prints, distributes, releases, issues, or produces the

--- a/lib/plugins/EPrints/Plugin/Screen/EPrint/Staff/CoinDOI.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/EPrint/Staff/CoinDOI.pm
@@ -54,7 +54,7 @@ sub allow_coindoi
         !$repository->get_conf("datacitedoi","allow_custom_doi"));
 	#TODO don't allow the coinDOI button if a DOI is already registered (may require a db flag for successful reg)
     # Or maybe check with datacite api to see if a doi is registered
-    return $self->allow( "eprint/edit:editor" );
+    return $self->allow( $repository->get_conf( "datacitedoi", "minters") );
 }
 
 sub action_coindoi


### PR DESCRIPTION
Not everyone who can edit should necesarily be allowed to coin a DOI.

With this change the permission/role specifying who can mint becomes
configurable with its default value being the current setting.