### PR TITLE
Move from Crypt::SSLeay to LWP::Protocol::https

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In order to use the DataCite API the plugin requires the following perl librarie
 
 ```
 use LWP;
-use Crypt::SSLeay;
+use LWP::Protocol::https;
 ```
 
 Installation

--- a/lib/plugins/EPrints/Plugin/Event/DataCiteEvent.pm
+++ b/lib/plugins/EPrints/Plugin/Event/DataCiteEvent.pm
@@ -8,7 +8,6 @@ package EPrints::Plugin::Event::DataCiteEvent;
 
 use EPrints::Plugin::Event;
 use LWP;
-use Crypt::SSLeay;
 use HTTP::Headers::Util;
 
 @ISA = qw( EPrints::Plugin::Event );


### PR DESCRIPTION
As reported in #14, Crypt::SSLeay is no longer the recommended way of getting
HTTPS through LWP.

https://wiki.eprints.org/w/index.php?title=Installing_EPrints_on_RHEL/Fedora/CentOS&diff=prev&oldid=12408

This is also backed up by Crypt::SSLeay upstream who warn
```
At this point, Crypt::SSLeay is maintained to support existing software that
already depends on it. However, it is possible that your software does not
really depend on Crypt::SSLeay, only on the ability of LWP::UserAgent class to
communicate with sites over SSL/TLS.
```

https://metacpan.org/pod/Crypt::SSLeay#DO-YOU-NEED-Crypt::SSLeay?

Closes: #14
Closes: #23