### PR TITLE
Include matched regex and DOI prefix in error message

### DIFF
--- a/lib/cfg.d/z_datacite_mapping.pl
+++ b/lib/cfg.d/z_datacite_mapping.pl
@@ -477,6 +477,8 @@ $c->{validate_datacite} = sub
 		if ((hostname =~ $test_regex) && ("10.5072" != $doi_prefix)) {
 			push @problems, $repository->html_phrase(
 				"datacite_validate:doi_prefix_mismatch",
+				match_regexp=> $xml->create_text_node("$test_regex"),
+				configured_doi_prefix=> $xml->create_text_node("$doi_prefix"),
 			);
 		}
 	}

--- a/lib/lang/en/phrases/coinDOI.xml
+++ b/lib/lang/en/phrases/coinDOI.xml
@@ -125,7 +125,8 @@
 
     <epp:phrase id="datacite_validate:need_published_year"><p>There are no suitable values for the mandatory field <strong>datacite:PublicationYear</strong>. Please supply a <epc:pin name="dates">publication date</epc:pin> before coining a DOI.</p></epp:phrase>
 
-    <epp:phrase id="datacite_validate:doi_prefix_mismatch"><p>Your server hostname matches test_host_regex but is not using the test DOI prefix of 10.5072.</p></epp:phrase>
+    <epp:phrase id="datacite_validate:doi_prefix_mismatch"><p>Your server hostname matches the preprod regex <strong><epc:pin name="match_regexp" textonly="yes" /></strong> but is not using the test DOI prefix - current prefix is <strong><epc:pin name="configured_doi_prefix" /></strong>.</p></epp:phrase>
+
 
 
 </epp:phrases>


### PR DESCRIPTION
I attempted to include this in the original version of the changes but couldn't
get it working until I stumbled upon
https://wiki.eprints.org/w/index.php?title=My_First_Bazaar_Package and its
example Hello.pm.

Message now includes the matched regex and doi prefix in the error message,
bolded for readability.