### PR TITLE
Run mappings during export

### DIFF
--- a/lib/cfg.d/z_datacite_mapping.pl
+++ b/lib/cfg.d/z_datacite_mapping.pl
@@ -328,17 +328,19 @@ $c->{datacite_mapping_funders} = sub {
     # funder_id => funderIdentifier
 
     #Funders and projects are default eprints field, both are multiple
-    my $funders = $dataobj->get_value("funders");
-    my $projects = $dataobj->get_value("projects");
+    my $funders = undef;
+    my $projects = undef;
 
     my $fundingReferences = undef;
     if ($dataobj->exists_and_set("funders")) {
+        $funders = $dataobj->get_value("funders");
         my $i=0;
         $fundingReferences = $xml->create_element("fundingReferences");
         foreach my $funderName(@$funders) {
             $fundingReferences->appendChild(my $fundingReference = $xml->create_element("fundingReference"));
             $fundingReference->appendChild($xml->create_data_element("funderName", $funderName));
             if($dataobj->exists_and_set("projects")){
+	        $projects = $dataobj->get_value("projects");
                 if(ref($projects) =~ /ARRAY/) {
                     my $project = $projects->[scalar(@$projects)-1];
                     if(defined $projects->[$i]){

--- a/lib/cfg.d/z_datacite_mapping.pl
+++ b/lib/cfg.d/z_datacite_mapping.pl
@@ -167,7 +167,7 @@ $c->{datacite_mapping_date} = sub {
 
     my $publicationYear = undef;
     my $pub_year = undef;
-    if($dataobj->exists_and_set("date") && $dataobj->value("date_type") eq "published"){
+    if($dataobj->exists_and_set("date")) {
         $dataobj->get_value( "date" ) =~ /^([0-9]{4})/;
         $pub_year = $1;
     }
@@ -518,7 +518,7 @@ $c->{validate_datacite} = sub
                 default_publisher => $default_publisher);
 	}
 
-	if( !$eprint->is_set( "date" ) && (!$eprint->is_set( "date_type" ) || $eprint->value( "date_type" ) eq "published") )
+	if( !$eprint->is_set( "date" ) || !$eprint->is_set( "date_type" ) || ($eprint->value( "date_type" ) ne "published") )
 	{
 		my $dates = $xml->create_element( "span", class=>"ep_problem_field:dates" );
 

--- a/lib/plugins/EPrints/Plugin/Export/DataCiteXML.pm
+++ b/lib/plugins/EPrints/Plugin/Export/DataCiteXML.pm
@@ -59,23 +59,18 @@ sub output_dataobj
     }
     $entry->appendChild( $xml->create_data_element( "identifier", $thisdoi , identifierType=>"DOI" ) );
     
-    foreach my $field ( $dataobj->{dataset}->get_fields ){
-            my $mapping_fn = "datacite_mapping_".$field->get_name;
+    my $conf_hash_reference = $repo->{config};
+    foreach my $mapping_fn (keys %$conf_hash_reference){
+        # If this is a datacite_mapping configuration item (aka one of our subroutines)
+        if (index($mapping_fn, 'datacite_mapping_') == 0) {
+            # Value of $mapping_fn matches datacite_mapping_, so is probably a helper method
             if($repo->can_call($mapping_fn)){
                     my $mapped_element = $repo->call( $mapping_fn, $xml, $dataobj, $repo );
                     $entry->appendChild( $mapped_element ) if(defined $mapped_element);
             }
+        }
      }
      
-     # Add in our publisher from the config (Disabled, see #35)
-     # $entry->appendChild( $xml->create_data_element( "publisher", $repo->get_conf( "datacitedoi", "publisher") ) );
-    
-        # There is no field for rights at EPrints level so we derive rights from document
-        # metadata and as such we need to call our derivation routine outside the above loop
-        if($repo->can_call("datacite_mapping_rights_from_docs")){
-                    my $mapped_element = $repo->call( "datacite_mapping_rights_from_docs", $xml, $dataobj, $repo );
-                    $entry->appendChild( $mapped_element ) if(defined $mapped_element);
-            }
 ####### From here on in you can redefine datacite_mapping_[fieldname] sub routines in lib/cfg.d/zzz_datacite_mapping.pl  #######################
 
 


### PR DESCRIPTION
TL;DR: this change removes the dependence on specific eprints fields
having values when performing the XML export.

This expands on the change in 336a27c ("reworked Export plugin so that *any* EPrint field can be mapped if corresponding sub is found in zzz_datacite_mapping") and removes the change required in f8a3259 because now we run all maps.

It moves from an 'eprint first' configuration to a 'mapping function first'
which permits:
- Setting default values (like Publisher)
- Choosing the eprint fields data comes from (You have a custom date field? no worries).
- Adding new values to output XML by adding a new mapping function
- Basically, running arbitrary code. But don't do that.

Of course, anyone adding new mappings or overriding existing mappings will need
to handle the resulting validation problems themselves...

This is the export components work required to complete #35; optional changes
to validation would facilitiate the second part but validation can be done via
overrides per site.

Closes: #35
