### PR TITLE
fixing funderIdentifier element issue to comply with schema 4.0 (and …

### DIFF
--- a/lib/cfg.d/z_datacite_mapping.pl
+++ b/lib/cfg.d/z_datacite_mapping.pl
@@ -383,7 +383,7 @@ $c->{datacite_mapping_funders} = sub {
             $fundingReferences->appendChild(my $fundingReference = $xml->create_element("fundingReference"));
             $fundingReference->appendChild($xml->create_data_element("funderName", $project->{funder_name}));
             $fundingReference->appendChild($xml->create_data_element("awardTitle", $project->{project}));
-            $fundingReference->appendChild($xml->create_data_element("funderId", $project->{funder_id}));
+            $fundingReference->appendChild($xml->create_data_element("funderIdentifier", $project->{funder_id}));
         }
     } 
 


### PR DESCRIPTION
Hello,

This is a small change in the light of the fact that Datacite schema 4.0 and 4.1 specify that the funder's ID should map to funderIdentifier and not to funderId.

https://schema.datacite.org/meta/kernel-4.0/doc/DataCite-MetadataKernel_v4.0.pdf

Thanks!
Michele