### PR TITLE
Implements #64 by using Crockford Base32 to encode DOI suffix

### DIFF
--- a/cfg/cfg.d/z_datacitedoi.pl
+++ b/cfg/cfg.d/z_datacitedoi.pl
@@ -124,6 +124,10 @@ $c->{datacitedoi}{delimiters} = ["/","."];
 # Will only work if what is found adheres to DOI syntax rules (obviously)
 $c->{datacitedoi}{allow_custom_doi} = 0;
 
+# If set, rather than using DOI suffix like repoid.01234567, which have semantic meaning and may become irrelevant
+# in future, encode this using Crockford Base32.
+$c->{datacitedoi}{use_cool_doi} = 0;
+
 #Datacite recommend digits of length 8-10 set this param to pad the id to required length
 $c->{datacitedoi}{zero_padding} = 8;
 

--- a/lib/plugins/EPrints/DataCite/Utils.pm
+++ b/lib/plugins/EPrints/DataCite/Utils.pm
@@ -32,7 +32,17 @@ sub generate_doi
 
     # construct the DOI string
     my $prefix = $repository->get_conf( "datacitedoi", "prefix" );
-    my $thisdoi = $prefix.$delim1.$repository->get_conf( "datacitedoi", "repoid" ).$delim2.$id;
+    my $suffix = $repository->get_conf( "datacitedoi", "repoid" ).$delim2.$id;
+    if ( $repository->get_conf( "datacitedoi", "use_cool_doi" ) )
+    {
+	    use Digest::MD5;
+	    use Encode::Base32::Crockford;
+	    # Get first 15 hex chars of the MD5 digest of the original suffix (16 chars could cause integer overflow).
+	    # Convert hex chars in decimal number and encode using Crockford Base32 and then lowercase the output for
+	    # greater readability.
+	    $suffix = lc( Encode::Base32::Crockford::base32_encode( hex( "0x". substr( Digest::MD5::md5_hex( $suffix ), 0, 15 ) ) ) );
+    }
+    my $thisdoi = $prefix.$delim1.$suffix;
     
     return $thisdoi;    
 }


### PR DESCRIPTION
As recommended by https://datacite.org/blog/cool-dois/ albeit with a few tweaks to use original DOI suffix as a seed, avoid needing more than necessary extra Perl modules and to giving best readability.