### PR TITLE
Implements #64 by using Crockford Base32 to encode DOI suffix on 3_4 branch

### DIFF
--- a/cfg.d/z_datacitedoi.pl
+++ b/cfg.d/z_datacitedoi.pl
@@ -140,7 +140,8 @@ $c->{datacitedoi}{override_url} = undef;
 ##########################################
 # A custom method can be defined to generate a DOI to your own spec. This could be a sub, or point
 # to an existing method in the Utils module, such as 'Cool DOIs' using Crockford Base32
-# (see https://datacite.org/blog/cool-dois/)
+# (see https://datacite.org/blog/cool-dois/). NB the module Encode::Base32::Crockford must be installed
+# generate this style of DOI
 #$c->{datacitedoi}{override_url} = \&EPrints::DataCite::Utils::generate_doi_base32_crockford;
 # -or -
 #$c->{datacitedoi}{generate_doi_override} = sub

--- a/cfg.d/z_datacitedoi.pl
+++ b/cfg.d/z_datacitedoi.pl
@@ -134,6 +134,9 @@ $c->{datacitedoi}{zero_padding} = 8;
 #Only useful for testing from "wrong" domain (eg an unregistered test server) should be undef for normal operation
 $c->{datacitedoi}{override_url} = undef;
 
+# Alternatively, Generate Cool DOI using Crockford Base32 (see https://datacite.org/blog/cool-dois/)
+#$c->{datacitedoi}{override_url} = \&EPrints::DataCite::Utils::generate_doi_base32_crockford;
+
 ##########################
 ##### When to coin ? #####
 ##########################

--- a/cfg.d/z_datacitedoi.pl
+++ b/cfg.d/z_datacitedoi.pl
@@ -134,8 +134,21 @@ $c->{datacitedoi}{zero_padding} = 8;
 #Only useful for testing from "wrong" domain (eg an unregistered test server) should be undef for normal operation
 $c->{datacitedoi}{override_url} = undef;
 
-# Alternatively, Generate Cool DOI using Crockford Base32 (see https://datacite.org/blog/cool-dois/)
+
+##########################################
+### Format of DOI to be generated      ###
+##########################################
+# A custom method can be defined to generate a DOI to your own spec. This could be a sub, or point
+# to an existing method in the Utils module, such as 'Cool DOIs' using Crockford Base32
+# (see https://datacite.org/blog/cool-dois/)
 #$c->{datacitedoi}{override_url} = \&EPrints::DataCite::Utils::generate_doi_base32_crockford;
+# -or -
+#$c->{datacitedoi}{generate_doi_override} = sub
+#{
+#	my( $repo, $dataobj ) = @_;
+#	... generate the full DOI (including the prefix). See Utils.pm for inspiration.
+#	return $thisdoi;
+#}
 
 ##########################
 ##### When to coin ? #####

--- a/cfg.d/z_datacitedoi.pl
+++ b/cfg.d/z_datacitedoi.pl
@@ -142,7 +142,7 @@ $c->{datacitedoi}{override_url} = undef;
 # to an existing method in the Utils module, such as 'Cool DOIs' using Crockford Base32
 # (see https://datacite.org/blog/cool-dois/). NB the module Encode::Base32::Crockford must be installed
 # generate this style of DOI
-#$c->{datacitedoi}{override_url} = \&EPrints::DataCite::Utils::generate_doi_base32_crockford;
+#$c->{datacitedoi}{generate_doi_override} = \&EPrints::DataCite::Utils::generate_doi_base32_crockford;
 # -or -
 #$c->{datacitedoi}{generate_doi_override} = sub
 #{

--- a/plugins/EPrints/DataCite/Utils.pm
+++ b/plugins/EPrints/DataCite/Utils.pm
@@ -6,20 +6,15 @@ use Encode;
 
 use strict;
 
-sub generate_doi
+sub generate_default_doi
 {
     my( $repository, $dataobj ) = @_;
-
-    if( $repository->can_call( "generate_doi_override" ) )
-    {
-        return $repository->call( "generate_doi_override", $repository, $dataobj );
-    }
 
     my $z_pad = $repository->get_conf( "datacitedoi", "zero_padding") || 0;
 
     my $id = $dataobj->id;
     $id  = sprintf( "%0" . $z_pad . "d" , $id );
-   
+
     if( $dataobj->get_dataset_id eq "document" )
     {
         my $eprintid = $dataobj->get_eprint->id;
@@ -38,8 +33,21 @@ sub generate_doi
     # construct the DOI string
     my $prefix = $repository->get_conf( "datacitedoi", "prefix" );
     my $thisdoi = $prefix.$delim1.$repository->get_conf( "datacitedoi", "repoid" ).$delim2.$id;
-    
-    return $thisdoi;    
+
+    return $thisdoi;
+
+}
+
+sub generate_doi
+{
+    my( $repository, $dataobj ) = @_;
+
+    if( $repository->can_call( "generate_doi_override" ) )
+    {
+        return $repository->call( "generate_doi_override", $repository, $dataobj );
+    }
+
+    return generate_default_doi( $repository, $dataobj );
 }
 
 # reserve a doi, a.k.a create draft doi
@@ -288,6 +296,32 @@ sub create_related_identifier
     {
         return undef;
     }
+}
+
+sub generate_doi_base32_crockford
+{
+    my( $repository, $dataobj ) = @_;
+
+    use Digest::MD5;
+    use Encode::Base32::Crockford;
+    my( $delim1, $delim2 ) = @{$repository->get_conf( "datacitedoi", "delimiters" )};
+
+    # Get default DOI
+    $thisdoi = generate_default_doi( $repository, $dataobj );
+
+    # Split to get out suffix and prefix
+    my ( $doi_prefix, $doi_suffix ) = split( $delim1, $thisdoi, 2 );
+
+    # Get first 15 hex chars of the MD5 digest of the original suffix (16 chars could cause integer overflow).
+    my $md5_hex = substr( Digest::MD5::md5_hex( $doi_suffix ), 0, 15 );
+
+    # Convert hex chars in decimal number and encode using Crockford Base32 and then lowercase the output for greater readability.
+    $doi_suffix  = lc( Encode::Base32::Crockford::base32_encode(  hex( "0x". $md5_hex ) );
+
+    # Put DOI back together gain
+    $thisdoi = $doi_prefix . $delim1 . $doi_suffix;
+
+    return $thisdoi;
 }
 
 1;

--- a/plugins/EPrints/DataCite/Utils.pm
+++ b/plugins/EPrints/DataCite/Utils.pm
@@ -300,28 +300,34 @@ sub create_related_identifier
 
 sub generate_doi_base32_crockford
 {
-    my( $repository, $dataobj ) = @_;
+	my( $repository, $dataobj ) = @_;
 
-    use Digest::MD5;
-    use Encode::Base32::Crockford;
-    my( $delim1, $delim2 ) = @{$repository->get_conf( "datacitedoi", "delimiters" )};
+	use Digest::MD5;
+	eval "use Encode::Base32::Crockford";
+	if($@) 
+	{
+		print STDERR "Unable to import Encode::Base32::Crockford\n";
+		return;
+	}
 
-    # Get default DOI
-    my $thisdoi = generate_default_doi( $repository, $dataobj );
+	my( $delim1, $delim2 ) = @{$repository->get_conf( "datacitedoi", "delimiters" )};
 
-    # Split to get out suffix and prefix
-    my ( $doi_prefix, $doi_suffix ) = split( $delim1, $thisdoi, 2 );
+	# Get default DOI
+	my $thisdoi = generate_default_doi( $repository, $dataobj );
 
-    # Get first 15 hex chars of the MD5 digest of the original suffix (16 chars could cause integer overflow).
-    my $md5_hex = substr( Digest::MD5::md5_hex( $doi_suffix ), 0, 15 );
+	# Split to get out suffix and prefix
+	my ( $doi_prefix, $doi_suffix ) = split( $delim1, $thisdoi, 2 );
 
-    # Convert hex chars in decimal number and encode using Crockford Base32 and then lowercase the output for greater readability.
-    $doi_suffix  = lc( Encode::Base32::Crockford::base32_encode(  hex( "0x". $md5_hex ) ) );
+	# Get first 15 hex chars of the MD5 digest of the original suffix (16 chars could cause integer overflow).
+	my $md5_hex = substr( Digest::MD5::md5_hex( $doi_suffix ), 0, 15 );
 
-    # Put DOI back together gain
-    $thisdoi = $doi_prefix . $delim1 . $doi_suffix;
+	# Convert hex chars in decimal number and encode using Crockford Base32 and then lowercase the output for greater readability.
+	$doi_suffix  = lc( Encode::Base32::Crockford::base32_encode(  hex( "0x". $md5_hex ) ) );
 
-    return $thisdoi;
+	# Put DOI back together gain
+	$thisdoi = $doi_prefix . $delim1 . $doi_suffix;
+
+	return $thisdoi;
 }
 
 1;

--- a/plugins/EPrints/DataCite/Utils.pm
+++ b/plugins/EPrints/DataCite/Utils.pm
@@ -322,6 +322,8 @@ sub generate_doi_base32_crockford
 	my $md5_hex = substr( Digest::MD5::md5_hex( $doi_suffix ), 0, 15 );
 
 	# Convert hex chars in decimal number and encode using Crockford Base32 and then lowercase the output for greater readability.
+	# Suppress "Hexadecimal number > 0xffffffff non-portable" warning
+	no warnings 'portable';
 	$doi_suffix = lc( Encode::Base32::Crockford::base32_encode(  hex( "0x". $md5_hex ) ) );
 
 	# Insert hyphen every 4 characters (last block may have 1,2 or 3 characters e.g. xxxx-xxxx-x)

--- a/plugins/EPrints/DataCite/Utils.pm
+++ b/plugins/EPrints/DataCite/Utils.pm
@@ -307,7 +307,7 @@ sub generate_doi_base32_crockford
     my( $delim1, $delim2 ) = @{$repository->get_conf( "datacitedoi", "delimiters" )};
 
     # Get default DOI
-    $thisdoi = generate_default_doi( $repository, $dataobj );
+    my $thisdoi = generate_default_doi( $repository, $dataobj );
 
     # Split to get out suffix and prefix
     my ( $doi_prefix, $doi_suffix ) = split( $delim1, $thisdoi, 2 );
@@ -316,7 +316,7 @@ sub generate_doi_base32_crockford
     my $md5_hex = substr( Digest::MD5::md5_hex( $doi_suffix ), 0, 15 );
 
     # Convert hex chars in decimal number and encode using Crockford Base32 and then lowercase the output for greater readability.
-    $doi_suffix  = lc( Encode::Base32::Crockford::base32_encode(  hex( "0x". $md5_hex ) );
+    $doi_suffix  = lc( Encode::Base32::Crockford::base32_encode(  hex( "0x". $md5_hex ) ) );
 
     # Put DOI back together gain
     $thisdoi = $doi_prefix . $delim1 . $doi_suffix;

--- a/plugins/EPrints/DataCite/Utils.pm
+++ b/plugins/EPrints/DataCite/Utils.pm
@@ -42,9 +42,9 @@ sub generate_doi
 {
     my( $repository, $dataobj ) = @_;
 
-    if( $repository->can_call( "generate_doi_override" ) )
+    if( $repository->can_call( "datacitedoi", "generate_doi_override" ) )
     {
-        return $repository->call( "generate_doi_override", $repository, $dataobj );
+        return $repository->call( [ "datacitedoi", "generate_doi_override" ], $repository, $dataobj );
     }
 
     return generate_default_doi( $repository, $dataobj );

--- a/plugins/EPrints/DataCite/Utils.pm
+++ b/plugins/EPrints/DataCite/Utils.pm
@@ -322,7 +322,10 @@ sub generate_doi_base32_crockford
 	my $md5_hex = substr( Digest::MD5::md5_hex( $doi_suffix ), 0, 15 );
 
 	# Convert hex chars in decimal number and encode using Crockford Base32 and then lowercase the output for greater readability.
-	$doi_suffix  = lc( Encode::Base32::Crockford::base32_encode(  hex( "0x". $md5_hex ) ) );
+	$doi_suffix = lc( Encode::Base32::Crockford::base32_encode(  hex( "0x". $md5_hex ) ) );
+
+	# Insert hyphen every 4 characters (last block may have 1,2 or 3 characters e.g. xxxx-xxxx-x)
+	$doi_suffix =~ s/(.{4})(?!$)/$1-/g;
 
 	# Put DOI back together gain
 	$thisdoi = $doi_prefix . $delim1 . $doi_suffix;


### PR DESCRIPTION
This is still a bit of a WIP. I have tested the syntax but do not have easy access to a test system with a DataCite test account. However, it would be useful to do an initial review to see if there are any glaring issues without how this will interact with recent changes to DataCiteDoi, particularly in the 3_4 branch.
